### PR TITLE
Fix typo in Cisco ACI roles

### DIFF
--- a/roles/aci/tasks/firewall.yml
+++ b/roles/aci/tasks/firewall.yml
@@ -23,4 +23,4 @@
       immediate: true
       state: enabled
     when: item.cond | default(True)
-    with_items: "{{ r_aci_node_os_firewall_all }}"
+    with_items: "{{ r_aci_node_os_firewall_allow }}"


### PR DESCRIPTION
Fixing the reference to the variable name from "r_aci_node_os_firewall_all" to "r_aci_node_os_firewall_allow”.
(cherry picked from commit 4340af6a36edd6123733c436e711cc026b991322)